### PR TITLE
Fix invalid routing path due to spaces inside the json

### DIFF
--- a/core/routing_providers.py
+++ b/core/routing_providers.py
@@ -5,6 +5,7 @@ from core import constants
 from core.way import Way
 
 from urllib.request import urlopen
+from urllib.parse import quote
 
 try:
     import json
@@ -313,7 +314,7 @@ class OSMScoutServerRouting(RoutingProvider):
                 'directions_options': { 'language': route_params.language },
                 'locations': locations
             }
-            queryUrl = OSM_SCOUT_SERVER_ROUTING_URL + "json=" + json.dumps(params)
+            queryUrl = OSM_SCOUT_SERVER_ROUTING_URL + "json=" + quote(json.dumps(params))
             reply = urlopen(queryUrl)
             
             if reply:


### PR DESCRIPTION
In newer versions, urllib rejects paths containing control characters,
which includes spaces. Since `json.dumps` adds spaces by default, this
caused the request to be rejected locally, preventing routing from
working.

This change was tested on my device and works locally. Tested with the
most recent version of osm-scout-server on SFOS 3.3.